### PR TITLE
Kill process groups instead of single processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ language: go
 go:
   - 1.7
 
+env:
+  - ARCHS=linux/amd64
+
 script:
   - make ci


### PR DESCRIPTION
To make sure that all childs of the forked processes for checks are killed too on timeouts instead of just the check's process.

We were seeing leaking Go routines as well as wrong metrics because Go routines have been waiting forever for processes to finish. This change is based off the ideas from https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773.